### PR TITLE
Remove "valid" value from status prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@inubekit/your-component-name",
+  "name": "@inubekit/datefield",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@inubekit/your-component-name",
+      "name": "@inubekit/datefield",
       "version": "1.0.0",
       "dependencies": {
         "@inubekit/foundations": "^2.5.0",

--- a/src/Datefield/props.ts
+++ b/src/Datefield/props.ts
@@ -1,7 +1,7 @@
 const sizes = ["wide", "compact"] as const;
 type Size = (typeof sizes)[number];
 
-const status = ["valid", "invalid", "pending"] as const;
+const status = ["invalid", "pending"] as const;
 type Status = (typeof status)[number];
 
 const parameters = {

--- a/src/Datefield/stories/DatefieldController.tsx
+++ b/src/Datefield/stories/DatefieldController.tsx
@@ -25,7 +25,7 @@ const DatefieldController = (props: IDatefield) => {
   const onBlur = (e: React.ChangeEvent<HTMLInputElement>) => {
     const isValid = isValidDate(e.target.value);
     console.log("isValid: ", isValid, e.target.value, typeof e.target.value);
-    setForm({ ...form, status: isValid ? "valid" : "invalid" });
+    setForm({ ...form, status: isValid ? "pending" : "invalid" });
   };
 
   const message = "the date is not valid.";


### PR DESCRIPTION
This pull request encompasses the removal of the 'valid' value option from the status prop across specific UI components within our application. Aimed at simplifying the component interface and enhancing usability, this update aligns with our initiative to streamline prop configurations and maintain consistency in indicating component states.