### PR TITLE
Publish new version 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# v2.1.0 (Fri Mar 22 2024)
+
+#### 🚀 Enhancement
+
+- Adjust and export interfaces [#5](https://github.com/selsa-inube/inubekit-datefield/pull/5) ([@cmarin001](https://github.com/cmarin001))
+
+#### 📝 Documentation
+
+- Publish new version 2.0.0 [#4](https://github.com/selsa-inube/inubekit-datefield/pull/4) ([@cmarin001](https://github.com/cmarin001))
+
+#### 🔩 Dependency Updates
+
+- Update inubekit/datefield to storybook v8 [#6](https://github.com/selsa-inube/inubekit-datefield/pull/6) ([@cmarin001](https://github.com/cmarin001))
+
+#### Authors: 1
+
+- Cesar Marin Alfonso ([@cmarin001](https://github.com/cmarin001))
+
+---
+
 # v2.0.0 (Tue Mar 19 2024)
 
 #### 💥 Breaking Change

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inubekit/datefield",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inubekit/datefield",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "@inubekit/foundations": "^2.5.0",
         "@inubekit/icon": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "description": "",
   "private": false,
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
# v2.1.0 (Fri Mar 22 2024)

#### 🚀 Enhancement

- Adjust and export interfaces [#5](https://github.com/selsa-inube/inubekit-datefield/pull/5) ([@cmarin001](https://github.com/cmarin001))

#### 📝 Documentation

- Publish new version 2.0.0 [#4](https://github.com/selsa-inube/inubekit-datefield/pull/4) ([@cmarin001](https://github.com/cmarin001))

#### 🔩 Dependency Updates

- Update inubekit/datefield to storybook v8 [#6](https://github.com/selsa-inube/inubekit-datefield/pull/6) ([@cmarin001](https://github.com/cmarin001))

#### Authors: 1

- Cesar Marin Alfonso ([@cmarin001](https://github.com/cmarin001))

---